### PR TITLE
Add README documenting enum tree functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# enum_tree
+
+`enum_tree` provides traits and derive macros for modeling a tree of enums.
+Each enum in the tree knows its parent and the root so values can be
+converted to or recovered from the root at runtime.
+
+The repository contains two crates:
+
+- **enum_tree** – defines the [`EnumTree`] trait along with marker traits
+  [`EnumTreeRoot`], [`EnumTreeInner`], [`EnumTreeLeaf`] and conversion traits
+  [`ToEnumTreeRoot`] and [`TryFromEnumTreeRoot`].
+- **enum_tree_derive** – implements `#[derive(EnumTree)]` and supporting
+  attributes that generate the boilerplate implementations.
+
+## Deriving a tree
+
+An enum tree always has a single root. The `#[enum_tree_root]` attribute marks
+that root enum. Inner and leaf enums specify their parent and root types using
+`#[enum_tree_inner(P, R)]` and `#[enum_tree_leaf(P, R)]` respectively. Variant
+names of parents must match the child enum names.
+
+```rust
+use enum_tree::EnumTree;
+
+#[derive(EnumTree)]
+#[enum_tree_root]
+pub enum AppAction {
+    Menu(MenuAction),
+    Exit,
+}
+
+#[derive(EnumTree)]
+#[enum_tree_inner(AppAction, AppAction)]
+pub enum MenuAction {
+    Settings(SettingsAction),
+    Quit,
+}
+
+#[derive(EnumTree)]
+#[enum_tree_leaf(MenuAction, AppAction)]
+pub enum SettingsAction {
+    ToggleSound,
+}
+```
+
+## Working with the tree
+
+Any node can be converted to the root via [`ToEnumTreeRoot::to_root`].
+The reverse conversion is available with
+[`TryFromEnumTreeRoot::from_root`].
+
+```rust
+use enum_tree::{EnumTree, ToEnumTreeRoot, TryFromEnumTreeRoot};
+
+let root = SettingsAction::ToggleSound.to_root();
+assert!(matches!(root, AppAction::Menu(MenuAction::Settings(SettingsAction::ToggleSound))));
+
+let back = SettingsAction::from_root(root).unwrap();
+assert_eq!(back, SettingsAction::ToggleSound);
+```
+
+The derive macros also implement `From` and `TryFrom` between parents and
+children, so manual conversions are straightforward.
+
+## License
+
+This project is licensed under the terms of the [MIT License](LICENSE).
+
+[`EnumTree`]: enum_tree/src/lib.rs
+[`EnumTreeRoot`]: enum_tree/src/lib.rs
+[`EnumTreeInner`]: enum_tree/src/lib.rs
+[`EnumTreeLeaf`]: enum_tree/src/lib.rs
+[`ToEnumTreeRoot`]: enum_tree/src/lib.rs
+[`TryFromEnumTreeRoot`]: enum_tree/src/lib.rs


### PR DESCRIPTION
## Summary
- describe enum_tree traits and macros
- provide examples for deriving enums and converting to/from root

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b4ea89846c8323967f8a04391db4e5