### PR TITLE
feat: allow enums in multiple trees

### DIFF
--- a/enum_tree/tests/multiple_roots.rs
+++ b/enum_tree/tests/multiple_roots.rs
@@ -1,0 +1,47 @@
+use enum_tree::{EnumTree, ToEnumTreeRoot, TryFromEnumTreeRoot};
+
+#[derive(EnumTree, Clone, Debug, PartialEq)]
+#[enum_tree_root]
+pub enum RootOne {
+    Parent(Parent),
+}
+
+#[derive(EnumTree, Clone, Debug, PartialEq)]
+#[enum_tree_root]
+pub enum RootTwo {
+    Parent(Parent),
+}
+
+#[derive(EnumTree, Clone, Debug, PartialEq)]
+#[enum_tree_inner(RootOne, RootOne)]
+#[enum_tree_inner(RootTwo, RootTwo)]
+pub enum Parent {
+    Leaf(Leaf),
+}
+
+#[derive(EnumTree, Clone, Debug, PartialEq)]
+#[enum_tree_leaf(Parent, RootOne)]
+#[enum_tree_leaf(Parent, RootTwo)]
+pub enum Leaf {
+    A,
+}
+
+#[test]
+fn test_to_root_multiple() {
+    let leaf = Leaf::A;
+    let r1: RootOne = leaf.clone().to_root();
+    let r2: RootTwo = leaf.clone().to_root();
+    assert!(matches!(r1, RootOne::Parent(Parent::Leaf(Leaf::A))));
+    assert!(matches!(r2, RootTwo::Parent(Parent::Leaf(Leaf::A))));
+}
+
+#[test]
+fn test_from_root_multiple() {
+    let leaf = Leaf::A;
+    let r1: RootOne = leaf.clone().to_root();
+    let r2: RootTwo = leaf.clone().to_root();
+    let l1 = <Leaf as TryFromEnumTreeRoot<RootOne>>::from_root(r1).unwrap();
+    let l2 = <Leaf as TryFromEnumTreeRoot<RootTwo>>::from_root(r2).unwrap();
+    assert_eq!(l1, leaf);
+    assert_eq!(l2, leaf);
+}

--- a/enum_tree/tests/parent_alias.rs
+++ b/enum_tree/tests/parent_alias.rs
@@ -1,0 +1,58 @@
+use enum_tree::{EnumTree, ToEnumTreeRoot, TryFromEnumTreeRoot};
+
+#[derive(EnumTree, Clone, Debug, PartialEq)]
+#[enum_tree_root]
+pub enum RootOne {
+    Parent(Parent),
+}
+
+#[derive(EnumTree, Clone, Debug, PartialEq)]
+#[enum_tree_root]
+pub enum RootTwo {
+    Parent(Parent),
+}
+
+mod nested {
+    use super::*;
+
+    #[derive(EnumTree, Clone, Debug, PartialEq)]
+    #[enum_tree_inner(super::Parent, RootOne)]
+    #[enum_tree_inner(crate::Parent, RootTwo)]
+    pub enum Child {
+        Leaf(Leaf),
+    }
+
+    #[derive(EnumTree, Clone, Debug, PartialEq)]
+    #[enum_tree_leaf(Child, RootOne)]
+    #[enum_tree_leaf(crate::nested::Child, RootTwo)]
+    pub enum Leaf {
+        A,
+    }
+}
+
+#[derive(EnumTree, Clone, Debug, PartialEq)]
+#[enum_tree_inner(RootOne, RootOne)]
+#[enum_tree_inner(RootTwo, RootTwo)]
+pub enum Parent {
+    Child(nested::Child),
+}
+
+#[test]
+fn test_to_root_alias_parent() {
+    let leaf = nested::Leaf::A;
+    let r1: RootOne = leaf.clone().to_root();
+    let r2: RootTwo = leaf.clone().to_root();
+    assert!(matches!(r1, RootOne::Parent(Parent::Child(nested::Child::Leaf(nested::Leaf::A)))));
+    assert!(matches!(r2, RootTwo::Parent(Parent::Child(nested::Child::Leaf(nested::Leaf::A)))));
+}
+
+#[test]
+fn test_from_root_alias_parent() {
+    let leaf = nested::Leaf::A;
+    let r1: RootOne = leaf.clone().to_root();
+    let r2: RootTwo = leaf.clone().to_root();
+    let l1 = <nested::Leaf as TryFromEnumTreeRoot<RootOne>>::from_root(r1).unwrap();
+    let l2 = <nested::Leaf as TryFromEnumTreeRoot<RootTwo>>::from_root(r2).unwrap();
+    assert_eq!(l1, leaf);
+    assert_eq!(l2, leaf);
+}

--- a/enum_tree_derive/src/lib.rs
+++ b/enum_tree_derive/src/lib.rs
@@ -1,5 +1,4 @@
 use proc_macro::TokenStream;
-use proc_macro2::Ident as PMIdent;
 use quote::quote;
 use syn::{Attribute, Data, DataEnum, DeriveInput, Fields, Type, spanned::Spanned};
 
@@ -37,28 +36,26 @@ pub fn enum_tree_derive(input: TokenStream) -> TokenStream {
 pub(crate) fn expand_enum_tree(input: DeriveInput) -> proc_macro2::TokenStream {
     let attrs = &input.attrs;
     let mut is_root = false;
-    let mut is_inner = None::<(Type, Type)>;
-    let mut is_leaf = None::<(Type, Type)>;
+    let mut has_inner = false;
+    let mut has_leaf = false;
 
     for attr in attrs {
         if attr.path().is_ident("enum_tree_root") {
             is_root = true;
         } else if attr.path().is_ident("enum_tree_inner") {
-            let (p, r) = parse_two_type_args(attr);
-            is_inner = Some((p, r));
+            has_inner = true;
         } else if attr.path().is_ident("enum_tree_leaf") {
-            let (p, r) = parse_two_type_args(attr);
-            is_leaf = Some((p, r));
+            has_leaf = true;
         }
     }
 
     if is_root {
         return expand_enum_tree_root(input);
     }
-    if let Some((_p, _r)) = is_inner {
+    if has_inner {
         return expand_enum_tree_inner(input);
     }
-    if let Some((_p, _r)) = is_leaf {
+    if has_leaf {
         return expand_enum_tree_leaf(input);
     }
 
@@ -70,96 +67,81 @@ pub(crate) fn expand_enum_tree(input: DeriveInput) -> proc_macro2::TokenStream {
 }
 
 pub(crate) fn expand_enum_tree_root(input: DeriveInput) -> proc_macro2::TokenStream {
-    let ident = input.ident;
+    let ident = input.ident.clone();
 
     quote! {
-        impl ::enum_tree::EnumTree for #ident {
+        impl ::enum_tree::EnumTree<#ident> for #ident {
             type P = ();
-            type R = #ident;
         }
-        impl ::enum_tree::EnumTreeRoot for #ident {}
+        impl ::enum_tree::EnumTreeRoot<#ident> for #ident {}
 
-        impl ::enum_tree::ToEnumTreeRoot for #ident {
-            fn to_root(self) -> Self::R { self }
+        impl ::enum_tree::ToEnumTreeRoot<#ident> for #ident {
+            fn to_root(self) -> #ident { self }
         }
 
-        impl ::enum_tree::TryFromEnumTreeRoot for #ident {
-            fn from_root(root: Self::R) -> Option<Self> { Some(root) }
+        impl ::enum_tree::TryFromEnumTreeRoot<#ident> for #ident {
+            fn from_root(root: #ident) -> Option<Self> { Some(root) }
         }
     }
 }
 
 pub(crate) fn expand_enum_tree_inner(input: DeriveInput) -> proc_macro2::TokenStream {
-    let ident = input.ident;
+    use std::collections::HashSet;
 
-    // Find enum_tree_inner(P,R)
-    let mut parent_ty: Option<Type> = None;
-    let mut root_ty: Option<Type> = None;
+    let ident = input.ident.clone();
+
+    // Collect all enum_tree_inner(P,R) attributes
+    let mut pairs: Vec<(Type, Type)> = Vec::new();
     for attr in input.attrs.iter() {
         if attr.path().is_ident("enum_tree_inner") {
-            let (p, r) = parse_two_type_args(attr);
-            parent_ty = Some(p);
-            root_ty = Some(r);
-            break;
+            pairs.push(parse_two_type_args(attr));
         }
     }
-    let p_ty = parent_ty.expect("missing parent type for enum_tree_inner");
-    let r_ty = root_ty.expect("missing root type for enum_tree_inner");
+    if pairs.is_empty() {
+        return syn::Error::new(input.span(), "missing parent type for enum_tree_inner")
+            .to_compile_error();
+    }
 
-    // Variant path name in parent/root assumed to match enum ident
-    let variant_ident = &ident;
-    let parent_ident = type_ident_from_type(&p_ty);
-    let root_ident = type_ident_from_type(&r_ty);
-    let parent_is_root =
-        parent_ident.is_some() && root_ident.is_some() && parent_ident == root_ident;
+    let variant_ident = &ident; // Variant name in parent equals enum name
 
-    if parent_is_root {
-        quote! {
-            impl ::enum_tree::EnumTree for #ident {
-                type P = #p_ty;
-                type R = #r_ty;
-            }
-            impl ::enum_tree::EnumTreeInner for #ident {}
+    // Generate impls for each (parent, root) pair
+    let mut enum_impls = Vec::new();
+    let mut from_impls = Vec::new();
+    let mut seen_parents: HashSet<String> = HashSet::new();
 
-            impl From<#ident> for #p_ty {
-                fn from(value: #ident) -> Self { #p_ty::#variant_ident(value) }
-            }
+    for (p_ty, r_ty) in &pairs {
+        enum_impls.push(quote! {
+            impl ::enum_tree::EnumTree<#r_ty> for #ident { type P = #p_ty; }
+            impl ::enum_tree::EnumTreeInner<#r_ty> for #ident {}
+        });
 
-            impl TryFrom<#p_ty> for #ident {
-                type Error = ();
-                fn try_from(value: #p_ty) -> Result<Self, Self::Error> {
-                    if let #p_ty::#variant_ident(v) = value { Ok(v) } else { Err(()) }
+        let p_str = quote!(#p_ty).to_string();
+        if seen_parents.insert(p_str) {
+            from_impls.push(quote! {
+                impl From<#ident> for #p_ty {
+                    fn from(value: #ident) -> Self { #p_ty::#variant_ident(value) }
                 }
-            }
 
-
-        }
-    } else {
-        quote! {
-            impl ::enum_tree::EnumTree for #ident {
-                type P = #p_ty;
-                type R = #r_ty;
-            }
-            impl ::enum_tree::EnumTreeInner for #ident {}
-
-            impl From<#ident> for #p_ty {
-                fn from(value: #ident) -> Self { #p_ty::#variant_ident(value) }
-            }
-
-            impl TryFrom<#p_ty> for #ident {
-                type Error = ();
-                fn try_from(value: #p_ty) -> Result<Self, Self::Error> {
-                    if let #p_ty::#variant_ident(v) = value { Ok(v) } else { Err(()) }
+                impl TryFrom<#p_ty> for #ident {
+                    type Error = ();
+                    fn try_from(value: #p_ty) -> Result<Self, Self::Error> {
+                        if let #p_ty::#variant_ident(v) = value { Ok(v) } else { Err(()) }
+                    }
                 }
-            }
-
-
+            });
         }
+    }
+
+    quote! {
+        #(#enum_impls)*
+        #(#from_impls)*
     }
 }
 
 pub(crate) fn expand_enum_tree_leaf(input: DeriveInput) -> proc_macro2::TokenStream {
-    let ident = input.ident;
+    use std::collections::HashSet;
+
+    let ident = input.ident.clone();
 
     // Validate leaf enum variants: only unit or struct (named fields). No tuple variants allowed.
     if let Data::Enum(DataEnum { variants, .. }) = &input.data {
@@ -177,42 +159,50 @@ pub(crate) fn expand_enum_tree_leaf(input: DeriveInput) -> proc_macro2::TokenStr
         }
     }
 
-    // Find enum_tree_leaf(P,R)
-    let mut parent_ty: Option<Type> = None;
-    let mut root_ty: Option<Type> = None;
+    // Collect all enum_tree_leaf(P,R) attributes
+    let mut pairs: Vec<(Type, Type)> = Vec::new();
     for attr in input.attrs.iter() {
         if attr.path().is_ident("enum_tree_leaf") {
-            let (p, r) = parse_two_type_args(attr);
-            parent_ty = Some(p);
-            root_ty = Some(r);
-            break;
+            pairs.push(parse_two_type_args(attr));
         }
     }
-    let p_ty = parent_ty.expect("missing parent type for enum_tree_leaf");
-    let r_ty = root_ty.expect("missing root type for enum_tree_leaf");
+    if pairs.is_empty() {
+        return syn::Error::new(input.span(), "missing parent type for enum_tree_leaf")
+            .to_compile_error();
+    }
 
     let parent_variant_ident = &ident; // Variant name in parent equals child enum name
 
+    let mut enum_impls = Vec::new();
+    let mut from_impls = Vec::new();
+    let mut seen_parents: HashSet<String> = HashSet::new();
+
+    for (p_ty, r_ty) in &pairs {
+        enum_impls.push(quote! {
+            impl ::enum_tree::EnumTree<#r_ty> for #ident { type P = #p_ty; }
+            impl ::enum_tree::EnumTreeLeaf<#r_ty> for #ident {}
+        });
+
+        let p_str = quote!(#p_ty).to_string();
+        if seen_parents.insert(p_str) {
+            from_impls.push(quote! {
+                impl From<#ident> for #p_ty {
+                    fn from(value: #ident) -> Self { #p_ty::#parent_variant_ident(value) }
+                }
+
+                impl TryFrom<#p_ty> for #ident {
+                    type Error = ();
+                    fn try_from(value: #p_ty) -> Result<Self, Self::Error> {
+                        if let #p_ty::#parent_variant_ident(v) = value { Ok(v) } else { Err(()) }
+                    }
+                }
+            });
+        }
+    }
+
     quote! {
-        impl ::enum_tree::EnumTree for #ident {
-            type P = #p_ty;
-            type R = #r_ty;
-        }
-        impl ::enum_tree::EnumTreeLeaf for #ident {}
-
-        impl From<#ident> for #p_ty {
-            fn from(value: #ident) -> Self { #p_ty::#parent_variant_ident(value) }
-        }
-
-        impl TryFrom<#p_ty> for #ident {
-            type Error = ();
-            fn try_from(value: #p_ty) -> Result<Self, Self::Error> {
-                if let #p_ty::#parent_variant_ident(v) = value { Ok(v) } else { Err(()) }
-            }
-        }
-
-    // #to_root_impl
-    // #try_from_root_impl
+        #(#enum_impls)*
+        #(#from_impls)*
     }
 }
 
@@ -230,13 +220,4 @@ fn parse_two_type_args(attr: &Attribute) -> (Type, Type) {
         .next()
         .expect("expected root type as second attribute argument");
     (p, r)
-}
-
-fn type_ident_from_type(ty: &Type) -> Option<PMIdent> {
-    if let Type::Path(tp) = ty {
-        if let Some(seg) = tp.path.segments.last() {
-            return Some(seg.ident.clone());
-        }
-    }
-    None
 }

--- a/enum_tree_derive/src/lib.rs
+++ b/enum_tree_derive/src/lib.rs
@@ -115,7 +115,7 @@ pub(crate) fn expand_enum_tree_inner(input: DeriveInput) -> proc_macro2::TokenSt
             impl ::enum_tree::EnumTreeInner<#r_ty> for #ident {}
         });
 
-        let p_str = quote!(#p_ty).to_string();
+        let p_str = type_key(p_ty);
         if seen_parents.insert(p_str) {
             from_impls.push(quote! {
                 impl From<#ident> for #p_ty {
@@ -183,7 +183,7 @@ pub(crate) fn expand_enum_tree_leaf(input: DeriveInput) -> proc_macro2::TokenStr
             impl ::enum_tree::EnumTreeLeaf<#r_ty> for #ident {}
         });
 
-        let p_str = quote!(#p_ty).to_string();
+        let p_str = type_key(p_ty);
         if seen_parents.insert(p_str) {
             from_impls.push(quote! {
                 impl From<#ident> for #p_ty {
@@ -220,4 +220,13 @@ fn parse_two_type_args(attr: &Attribute) -> (Type, Type) {
         .next()
         .expect("expected root type as second attribute argument");
     (p, r)
+}
+
+fn type_key(ty: &Type) -> String {
+    if let Type::Path(type_path) = ty {
+        if let Some(seg) = type_path.path.segments.last() {
+            return quote!(#seg).to_string();
+        }
+    }
+    quote!(#ty).to_string()
 }

--- a/enum_tree_derive/src/tests/mod.rs
+++ b/enum_tree_derive/src/tests/mod.rs
@@ -1,3 +1,5 @@
+mod test_expand_inner_multiple_roots;
+mod test_expand_leaf_multiple_roots;
 mod test_expand_leaf_tuple_variants;
 mod test_expand_leaf_under_root;
 mod test_expand_nested_enum_inner;

--- a/enum_tree_derive/src/tests/test_expand_inner_multiple_roots.rs
+++ b/enum_tree_derive/src/tests/test_expand_inner_multiple_roots.rs
@@ -1,0 +1,71 @@
+use pretty_assertions::assert_eq;
+use quote::quote;
+use syn::parse_quote;
+
+use crate::expand_enum_tree_inner;
+
+#[test]
+fn inner_multiple_roots_different_parents() {
+    let input: syn::DeriveInput = parse_quote! {
+        #[enum_tree_inner(ParentOne, RootOne)]
+        #[enum_tree_inner(ParentTwo, RootTwo)]
+        pub enum Child {
+            Leaf(Leaf),
+        }
+    };
+
+    let expected = quote! {
+        impl ::enum_tree::EnumTree<RootOne> for Child { type P = ParentOne; }
+        impl ::enum_tree::EnumTreeInner<RootOne> for Child {}
+        impl ::enum_tree::EnumTree<RootTwo> for Child { type P = ParentTwo; }
+        impl ::enum_tree::EnumTreeInner<RootTwo> for Child {}
+        impl From<Child> for ParentOne {
+            fn from(value: Child) -> Self { ParentOne::Child(value) }
+        }
+        impl TryFrom<ParentOne> for Child {
+            type Error = (); fn try_from(value: ParentOne) -> Result<Self, Self::Error> {
+                if let ParentOne::Child(v) = value { Ok(v) } else { Err(()) }
+            }
+        }
+        impl From<Child> for ParentTwo {
+            fn from(value: Child) -> Self { ParentTwo::Child(value) }
+        }
+        impl TryFrom<ParentTwo> for Child {
+            type Error = (); fn try_from(value: ParentTwo) -> Result<Self, Self::Error> {
+                if let ParentTwo::Child(v) = value { Ok(v) } else { Err(()) }
+            }
+        }
+    };
+
+    let actual = expand_enum_tree_inner(input);
+    assert_eq!(actual.to_string(), expected.to_string());
+}
+
+#[test]
+fn inner_multiple_roots_same_parent() {
+    let input: syn::DeriveInput = parse_quote! {
+        #[enum_tree_inner(Parent, RootOne)]
+        #[enum_tree_inner(Parent, RootTwo)]
+        pub enum Child {
+            Leaf(Leaf),
+        }
+    };
+
+    let expected = quote! {
+        impl ::enum_tree::EnumTree<RootOne> for Child { type P = Parent; }
+        impl ::enum_tree::EnumTreeInner<RootOne> for Child {}
+        impl ::enum_tree::EnumTree<RootTwo> for Child { type P = Parent; }
+        impl ::enum_tree::EnumTreeInner<RootTwo> for Child {}
+        impl From<Child> for Parent {
+            fn from(value: Child) -> Self { Parent::Child(value) }
+        }
+        impl TryFrom<Parent> for Child {
+            type Error = (); fn try_from(value: Parent) -> Result<Self, Self::Error> {
+                if let Parent::Child(v) = value { Ok(v) } else { Err(()) }
+            }
+        }
+    };
+
+    let actual = expand_enum_tree_inner(input);
+    assert_eq!(actual.to_string(), expected.to_string());
+}

--- a/enum_tree_derive/src/tests/test_expand_inner_multiple_roots.rs
+++ b/enum_tree_derive/src/tests/test_expand_inner_multiple_roots.rs
@@ -69,3 +69,32 @@ fn inner_multiple_roots_same_parent() {
     let actual = expand_enum_tree_inner(input);
     assert_eq!(actual.to_string(), expected.to_string());
 }
+
+#[test]
+fn inner_multiple_roots_same_parent_alias() {
+    let input: syn::DeriveInput = parse_quote! {
+        #[enum_tree_inner(super::Parent, RootOne)]
+        #[enum_tree_inner(crate::mods::Parent, RootTwo)]
+        pub enum Child {
+            Leaf(Leaf),
+        }
+    };
+
+    let expected = quote! {
+        impl ::enum_tree::EnumTree<RootOne> for Child { type P = super::Parent; }
+        impl ::enum_tree::EnumTreeInner<RootOne> for Child {}
+        impl ::enum_tree::EnumTree<RootTwo> for Child { type P = crate::mods::Parent; }
+        impl ::enum_tree::EnumTreeInner<RootTwo> for Child {}
+        impl From<Child> for super::Parent {
+            fn from(value: Child) -> Self { super::Parent::Child(value) }
+        }
+        impl TryFrom<super::Parent> for Child {
+            type Error = (); fn try_from(value: super::Parent) -> Result<Self, Self::Error> {
+                if let super::Parent::Child(v) = value { Ok(v) } else { Err(()) }
+            }
+        }
+    };
+
+    let actual = expand_enum_tree_inner(input);
+    assert_eq!(actual.to_string(), expected.to_string());
+}

--- a/enum_tree_derive/src/tests/test_expand_leaf_multiple_roots.rs
+++ b/enum_tree_derive/src/tests/test_expand_leaf_multiple_roots.rs
@@ -65,3 +65,30 @@ fn leaf_multiple_roots_same_parent() {
     let actual = expand_enum_tree_leaf(input);
     assert_eq!(actual.to_string(), expected.to_string());
 }
+
+#[test]
+fn leaf_multiple_roots_same_parent_alias() {
+    let input: syn::DeriveInput = parse_quote! {
+        #[enum_tree_leaf(super::Parent, RootOne)]
+        #[enum_tree_leaf(crate::mods::Parent, RootTwo)]
+        pub enum Leaf { Action }
+    };
+
+    let expected = quote! {
+        impl ::enum_tree::EnumTree<RootOne> for Leaf { type P = super::Parent; }
+        impl ::enum_tree::EnumTreeLeaf<RootOne> for Leaf {}
+        impl ::enum_tree::EnumTree<RootTwo> for Leaf { type P = crate::mods::Parent; }
+        impl ::enum_tree::EnumTreeLeaf<RootTwo> for Leaf {}
+        impl From<Leaf> for super::Parent {
+            fn from(value: Leaf) -> Self { super::Parent::Leaf(value) }
+        }
+        impl TryFrom<super::Parent> for Leaf {
+            type Error = (); fn try_from(value: super::Parent) -> Result<Self, Self::Error> {
+                if let super::Parent::Leaf(v) = value { Ok(v) } else { Err(()) }
+            }
+        }
+    };
+
+    let actual = expand_enum_tree_leaf(input);
+    assert_eq!(actual.to_string(), expected.to_string());
+}

--- a/enum_tree_derive/src/tests/test_expand_leaf_multiple_roots.rs
+++ b/enum_tree_derive/src/tests/test_expand_leaf_multiple_roots.rs
@@ -1,0 +1,67 @@
+use pretty_assertions::assert_eq;
+use quote::quote;
+use syn::parse_quote;
+
+use crate::expand_enum_tree_leaf;
+
+#[test]
+fn leaf_multiple_roots_different_parents() {
+    let input: syn::DeriveInput = parse_quote! {
+        #[enum_tree_leaf(ParentOne, RootOne)]
+        #[enum_tree_leaf(ParentTwo, RootTwo)]
+        pub enum Leaf { Action }
+    };
+
+    let expected = quote! {
+        impl ::enum_tree::EnumTree<RootOne> for Leaf { type P = ParentOne; }
+        impl ::enum_tree::EnumTreeLeaf<RootOne> for Leaf {}
+        impl ::enum_tree::EnumTree<RootTwo> for Leaf { type P = ParentTwo; }
+        impl ::enum_tree::EnumTreeLeaf<RootTwo> for Leaf {}
+        impl From<Leaf> for ParentOne {
+            fn from(value: Leaf) -> Self { ParentOne::Leaf(value) }
+        }
+        impl TryFrom<ParentOne> for Leaf {
+            type Error = (); fn try_from(value: ParentOne) -> Result<Self, Self::Error> {
+                if let ParentOne::Leaf(v) = value { Ok(v) } else { Err(()) }
+            }
+        }
+        impl From<Leaf> for ParentTwo {
+            fn from(value: Leaf) -> Self { ParentTwo::Leaf(value) }
+        }
+        impl TryFrom<ParentTwo> for Leaf {
+            type Error = (); fn try_from(value: ParentTwo) -> Result<Self, Self::Error> {
+                if let ParentTwo::Leaf(v) = value { Ok(v) } else { Err(()) }
+            }
+        }
+    };
+
+    let actual = expand_enum_tree_leaf(input);
+    assert_eq!(actual.to_string(), expected.to_string());
+}
+
+#[test]
+fn leaf_multiple_roots_same_parent() {
+    let input: syn::DeriveInput = parse_quote! {
+        #[enum_tree_leaf(Parent, RootOne)]
+        #[enum_tree_leaf(Parent, RootTwo)]
+        pub enum Leaf { Action }
+    };
+
+    let expected = quote! {
+        impl ::enum_tree::EnumTree<RootOne> for Leaf { type P = Parent; }
+        impl ::enum_tree::EnumTreeLeaf<RootOne> for Leaf {}
+        impl ::enum_tree::EnumTree<RootTwo> for Leaf { type P = Parent; }
+        impl ::enum_tree::EnumTreeLeaf<RootTwo> for Leaf {}
+        impl From<Leaf> for Parent {
+            fn from(value: Leaf) -> Self { Parent::Leaf(value) }
+        }
+        impl TryFrom<Parent> for Leaf {
+            type Error = (); fn try_from(value: Parent) -> Result<Self, Self::Error> {
+                if let Parent::Leaf(v) = value { Ok(v) } else { Err(()) }
+            }
+        }
+    };
+
+    let actual = expand_enum_tree_leaf(input);
+    assert_eq!(actual.to_string(), expected.to_string());
+}

--- a/enum_tree_derive/src/tests/test_expand_leaf_tuple_variants.rs
+++ b/enum_tree_derive/src/tests/test_expand_leaf_tuple_variants.rs
@@ -22,5 +22,8 @@ fn test_leaf_tuple_variants_rejected() {
 
     // This should eventually be rejected gracefully (no panic, a compile_error! or similar),
     // but for now we assert that it does NOT panic so this test fails until implemented.
-    assert!(!panicked, "Expected macro to reject leaf tuple variants without panicking");
+    assert!(
+        !panicked,
+        "Expected macro to reject leaf tuple variants without panicking"
+    );
 }

--- a/enum_tree_derive/src/tests/test_expand_leaf_under_root.rs
+++ b/enum_tree_derive/src/tests/test_expand_leaf_under_root.rs
@@ -12,11 +12,8 @@ fn leaf_directly_under_root() {
     };
 
     let expected = quote! {
-        impl ::enum_tree::EnumTree for AudioActions {
-            type P = RootAction;
-            type R = RootAction;
-        }
-        impl ::enum_tree::EnumTreeLeaf for AudioActions {}
+        impl ::enum_tree::EnumTree<RootAction> for AudioActions { type P = RootAction; }
+        impl ::enum_tree::EnumTreeLeaf<RootAction> for AudioActions {}
 
         impl From<AudioActions> for RootAction {
             fn from(value: AudioActions) -> Self { RootAction::AudioActions(value) }

--- a/enum_tree_derive/src/tests/test_expand_nested_enum_inner.rs
+++ b/enum_tree_derive/src/tests/test_expand_nested_enum_inner.rs
@@ -14,11 +14,8 @@ fn test_inner_simple() {
     };
 
     let expected = quote! {
-        impl ::enum_tree::EnumTree for MenuFlow {
-            type P = RootAction;
-            type R = RootAction;
-        }
-        impl ::enum_tree::EnumTreeInner for MenuFlow {}
+        impl ::enum_tree::EnumTree<RootAction> for MenuFlow { type P = RootAction; }
+        impl ::enum_tree::EnumTreeInner<RootAction> for MenuFlow {}
 
         impl From<MenuFlow> for RootAction {
             fn from(value: MenuFlow) -> Self { RootAction::MenuFlow(value) }
@@ -48,11 +45,8 @@ fn test_inner_nested_child() {
     };
 
     let expected = quote! {
-        impl ::enum_tree::EnumTree for Settings {
-            type P = MenuFlow;
-            type R = RootAction;
-        }
-        impl ::enum_tree::EnumTreeInner for Settings {}
+        impl ::enum_tree::EnumTree<RootAction> for Settings { type P = MenuFlow; }
+        impl ::enum_tree::EnumTreeInner<RootAction> for Settings {}
 
         impl From<Settings> for MenuFlow {
             fn from(value: Settings) -> Self { MenuFlow::Settings(value) }

--- a/enum_tree_derive/src/tests/test_expand_nested_enum_leaf.rs
+++ b/enum_tree_derive/src/tests/test_expand_nested_enum_leaf.rs
@@ -16,32 +16,25 @@ fn test_simple() {
     };
 
     let expected = quote! {
+        impl ::enum_tree::EnumTree<RootAction> for General { type P = MenuFlow; }
+        impl ::enum_tree::EnumTreeLeaf<RootAction> for General {}
 
-    impl ::enum_tree::EnumTree for General {
-          type P = MenuFlow;
-          type R = RootAction;
-      }
-        impl ::enum_tree::EnumTreeLeaf for General {}
+        impl From<General> for MenuFlow {
+            fn from(value: General) -> Self {
+                MenuFlow::General(value)
+            }
+        }
 
-      impl From<General> for MenuFlow {
-          fn from(value: General) -> Self {
-              MenuFlow::General(value)
-          }
-      }
-
-      impl TryFrom<MenuFlow> for General {
-          type Error = ();
-          fn try_from(value: MenuFlow) -> Result<Self, Self::Error> {
-              if let MenuFlow::General(v) = value {
-                  Ok(v)
-              } else {
-                  Err(())
-              }
-          }
-      }
-
-
-
+        impl TryFrom<MenuFlow> for General {
+            type Error = ();
+            fn try_from(value: MenuFlow) -> Result<Self, Self::Error> {
+                if let MenuFlow::General(v) = value {
+                    Ok(v)
+                } else {
+                    Err(())
+                }
+            }
+        }
     };
 
     let actual = expand_enum_tree_leaf(input);

--- a/enum_tree_derive/src/tests/test_expand_nested_enum_root.rs
+++ b/enum_tree_derive/src/tests/test_expand_nested_enum_root.rs
@@ -18,18 +18,15 @@ fn test_root_simple() {
     };
 
     let expected = quote! {
-        impl ::enum_tree::EnumTree for RootAction {
-            type P = ();
-            type R = RootAction;
-        }
-        impl ::enum_tree::EnumTreeRoot for RootAction {}
+        impl ::enum_tree::EnumTree<RootAction> for RootAction { type P = (); }
+        impl ::enum_tree::EnumTreeRoot<RootAction> for RootAction {}
 
-        impl ::enum_tree::ToEnumTreeRoot for RootAction {
-            fn to_root(self) -> Self::R { self }
+        impl ::enum_tree::ToEnumTreeRoot<RootAction> for RootAction {
+            fn to_root(self) -> RootAction { self }
         }
 
-        impl ::enum_tree::TryFromEnumTreeRoot for RootAction {
-            fn from_root(root: Self::R) -> Option<Self> { Some(root) }
+        impl ::enum_tree::TryFromEnumTreeRoot<RootAction> for RootAction {
+            fn from_root(root: RootAction) -> Option<Self> { Some(root) }
         }
     };
 


### PR DESCRIPTION
## Summary
- Make `EnumTree` generic over root so enums can belong to multiple trees
- Generate `EnumTree` impls for each `enum_tree_inner`/`leaf` attribute pair
- Test overlapping trees including cases sharing a parent but different roots

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b4eccbd5a08323adbb96bb62082400